### PR TITLE
Add travel time option to pyAll2Cloud.py

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,7 @@ pyAll2Cloud
 
 Done
 ====
-
+Added travel time option
 
 2Do
 ===
@@ -21,7 +21,8 @@ Example
 
 python pyall2cloud.py
 python pyall2cloud.py -i <filename.all>  
-python pyall2cloud.py -i *.all  
+python pyall2cloud.py -i *.all
+python pyall2cloud.py -i <filename.all> -t  
 
 help
 ----


### PR DESCRIPTION
I've added an option to allow pyAll2Cloud to extract values from N records that are generated from the most recent version of pyAll.py.

The new lines of code place the travel times in their corresponding beam number from the X record. Because the N record does not contain the current heading I thought this was the easiest solution in the short term. Ideally we would include an option to re-build the position from the travel time, angle and heading so that it will work successfully for *.all files that do not contain X records.